### PR TITLE
Add new supine exercises

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,28 @@ const exList=[
     desc:'膝を立てて腰をぐっと持ち上げ、お尻をギュッと締める' },
   { key:'bicycle', name:'バイシクルレッグ', time:30, sets:2,
     phases:[{d:2,t:'空中ペダル'}],
-    desc:'お腹で支える意識で脚を交互にこぐ' }
+    desc:'お腹で支える意識で脚を交互にこぐ' },
+  { key:'pelvic_reset', name:'深呼吸＋骨盤リセット', time:60, sets:1,
+    phases:[{d:3,t:'骨盤前へ'},{d:3,t:'骨盤後ろへ'}],
+    desc:'仰向けで両膝を立て、骨盤を前後にゆらしながら深呼吸' },
+  { key:'hip_hold', name:'ヒップリフトキープ', time:30, sets:3,
+    phases:[{d:30,t:'キープ'}],
+    desc:'腰を上げ30秒キープ×3回。間に10秒休憩' },
+  { key:'alt_knee_chest', name:'ニー・トゥ・チェスト（交互）', time:90, sets:1,
+    phases:[{d:2,t:'右膝'},{d:2,t:'左膝'}],
+    desc:'左右交互に胸へ引き寄せて下腹に効かせる' },
+  { key:'bicycle_kick', name:'バイシクルキック', time:60, sets:2,
+    phases:[{d:2,t:'キック'}],
+    desc:'休憩10秒を挟み2セットで腹斜筋に刺激' },
+  { key:'scissor_kick', name:'シザーキック', time:60, sets:2,
+    phases:[{d:2,t:'交差上下'}],
+    desc:'背中をつけたまま足を交差しながら上下する' },
+  { key:'arm_open_close', name:'腕伸ばしグーパー', time:60, sets:1,
+    phases:[{d:3,t:'グーパー×10'}],
+    desc:'腕を真上に伸ばし手をグーパー10回で血流促進' },
+  { key:'wrist_circles', name:'手首くるくる', time:40, sets:1,
+    phases:[{d:2,t:'右回し'},{d:2,t:'左回し'}],
+    desc:'腕を上に伸ばして手首をゆっくり回す' }
 ];
 
 /* ========= Accent randomiser ========= */


### PR DESCRIPTION
## Summary
- extend `exList` with new routines including pelvic resets, hip holds, alternating knee to chest, bicycle and scissor kicks
- add arm-focused moves such as stretch-and-squeeze and wrist circles

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685d95ef3a508321a18b4f945ee6b03c