### PR TITLE
makeRoutine関数の乱数処理を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,8 +369,9 @@ $('go').onclick=()=>{ci=0;cs=1;startEx()};
 function makeRoutine(){
   const normal=exList.filter(e=>!e.cooldown);
   const cool=exList.filter(e=>e.cooldown);
-  routine=[];
-  for(let i=0;i<3;i++) routine.push(normal.splice(Math.random()*normal.length|0,1)[0]);
+  normal.sort(()=>Math.random()-0.5);
+  routine=[]; // 安全のためリセット
+  routine.push(...normal.slice(0,3));
   routine.push(cool[Math.random()*cool.length|0]);
   const list=$('menu-list');list.innerHTML='';
   routine.forEach((ex,i)=>{


### PR DESCRIPTION
## 変更点
- `makeRoutine()` 内で通常エクササイズをシャッフル後に先頭3件を `routine` へ追加する形に修正
- 生成前に `routine` を空配列にリセットし、クールダウン系を1件追加する流れは維持

## テスト
- `git status --short` を実行し、作業ツリーがクリーンであることを確認


------
https://chatgpt.com/codex/tasks/task_e_685da8be22ac8321912e9b46983023ae